### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ $(".itemsList").selectonic({
     keyboard: true,
     select: function(event, ui) {
         // do something cool, for expample enable actions buttons
-    }
-	unselectAll: function(event, ui) {
+    },
+    unselectAll: function(event, ui) {
         // …and disable actions buttons
     }
 });


### PR DESCRIPTION
Without the comma after the select function in the specification of the properties of the selectonic plugin being called, this will throw an error.
